### PR TITLE
Add status via CodeLens

### DIFF
--- a/source/codelens.ts
+++ b/source/codelens.ts
@@ -10,7 +10,6 @@ class GhostTextCodeLensProvider implements vscode.CodeLensProvider {
 
 	provideCodeLenses(
 		document: vscode.TextDocument,
-		token: vscode.CancellationToken,
 	): vscode.ProviderResult<vscode.CodeLens[]> {
 		if (!documents.has(document.uri.toString())) {
 			return [];

--- a/source/codelens.ts
+++ b/source/codelens.ts
@@ -15,8 +15,7 @@ class GhostTextCodeLensProvider implements vscode.CodeLensProvider {
 			return [];
 		}
 
-		const firstLine = document.lineAt(0);
-		const range = new vscode.Range(0, 0, firstLine.range.start.line, 0);
+		const range = new vscode.Range(0, 0, 0, 0);
 		const command: vscode.Command = {
 			title: '👻 🌕 GhostText connected | Disconnect',
 			command: 'ghostText.disconnect',
@@ -29,7 +28,7 @@ class GhostTextCodeLensProvider implements vscode.CodeLensProvider {
 export function activate(context: vscode.ExtensionContext): void {
 	const codeLensProvider = new GhostTextCodeLensProvider();
 	const codeLensDisposable = vscode.languages.registerCodeLensProvider(
-		{scheme: 'untitled'},
+		{pattern: '**/*'},
 		codeLensProvider,
 	);
 	context.subscriptions.push(codeLensDisposable);

--- a/source/codelens.ts
+++ b/source/codelens.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+
+const enabledDocuments = new Set<string>();
+class GhostTextCodeLensProvider implements vscode.CodeLensProvider {
+	public readonly _onDidChangeCodeLenses: vscode.EventEmitter<void> =
+		new vscode.EventEmitter<void>();
+
+	public readonly onDidChangeCodeLenses: vscode.Event<void> =
+		this._onDidChangeCodeLenses.event;
+
+	provideCodeLenses(
+		document: vscode.TextDocument,
+		token: vscode.CancellationToken,
+	): vscode.ProviderResult<vscode.CodeLens[]> {
+		if (!enabledDocuments.has(document.uri.toString())) {
+			return [];
+		}
+
+		const firstLine = document.lineAt(0);
+		const range = new vscode.Range(0, 0, firstLine.range.start.line, 0);
+		const command: vscode.Command = {
+			title: '👻 🌕 GhostText connected | Disconnect',
+			command: 'ghostText.disconnect',
+			arguments: [document.uri.toString()],
+		};
+		return [new vscode.CodeLens(range, command)];
+	}
+}
+
+export function add(document: vscode.TextDocument) {
+	enabledDocuments.add(document.uri.toString());
+}
+
+export function remove(document: vscode.TextDocument) {
+	enabledDocuments.delete(document.uri.toString());
+}
+
+export function activate(context: vscode.ExtensionContext) {
+	const codeLensProvider = new GhostTextCodeLensProvider();
+	const codeLensDisposable = vscode.languages.registerCodeLensProvider(
+		{scheme: 'untitled'},
+		codeLensProvider,
+	);
+	const disconnectCommandDisposable = vscode.commands.registerCommand(
+		'ghostText.disconnect',
+		(uriString) => {
+			codeLensProvider._onDidChangeCodeLenses.fire(uriString)
+			const editor = vscode.window.activeTextEditor;
+			if (editor) {
+				enabledDocuments.delete(uriString);
+			}
+		},
+	);
+	context.subscriptions.push(codeLensDisposable, disconnectCommandDisposable);
+}

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -7,6 +7,7 @@ import process from 'node:process';
 import * as vscode from 'vscode';
 import {type WebSocket, Server} from 'ws';
 import filenamify from 'filenamify';
+import * as codelens from './codelens.js';
 
 const exec = promisify(execFile);
 let context: vscode.ExtensionContext;
@@ -37,7 +38,9 @@ async function createTab(title: string) {
 		viewColumn: vscode.ViewColumn.Active,
 		preview: false,
 	});
+
 	bringEditorToFront();
+	codelens.add(document);
 	return {document, editor};
 }
 
@@ -179,6 +182,7 @@ function createServer() {
 export function activate(_context: vscode.ExtensionContext) {
 	context = _context;
 	createServer();
+	codelens.activate(_context);
 
 	// Watch for changes to the HTTP port option
 	// This event is already debounced

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -197,7 +197,6 @@ function disconnectCommand(
 		| string
 		| undefined = vscode.window.activeTextEditor?.document.uri.toString(),
 ) {
-	console.log('Will disconnect', {uriString});
 	if (uriString) {
 		documents.delete(uriString);
 	}

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -176,73 +176,6 @@ function createServer() {
 	}
 }
 
-/**
- * CodelensProvider
- */
-export class CodelensProvider implements vscode.CodeLensProvider {
-	private codeLenses: vscode.CodeLens[] = [];
-	private readonly regex: RegExp;
-	private readonly _onDidChangeCodeLenses: vscode.EventEmitter<void> =
-		new vscode.EventEmitter<void>();
-
-	// eslint-disable-next-line @typescript-eslint/member-ordering
-	public readonly onDidChangeCodeLenses: vscode.Event<void> =
-		this._onDidChangeCodeLenses.event;
-
-	constructor() {
-		this.regex = /(.+)/g;
-
-		vscode.workspace.onDidChangeConfiguration((_) => {
-			this._onDidChangeCodeLenses.fire();
-		});
-	}
-
-	public provideCodeLenses(
-		document: vscode.TextDocument,
-		token: vscode.CancellationToken,
-	): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
-		if (
-			vscode.workspace
-				.getConfiguration('codelens-sample')
-				.get('enableCodeLens', true)
-		) {
-			this.codeLenses = [];
-			const regex = new RegExp(this.regex);
-			const text = document.getText();
-			let matches;
-			while ((matches = regex.exec(text)) !== null) {
-				const line = document.lineAt(document.positionAt(matches.index).line);
-				const indexOf = line.text.indexOf(matches[0]);
-				const position = new vscode.Position(line.lineNumber, indexOf);
-				const range = document.getWordRangeAtPosition(
-					position,
-					new RegExp(this.regex),
-				);
-				if (range) {
-					this.codeLenses.push(new vscode.CodeLens(range));
-				}
-			}
-
-			return this.codeLenses;
-		}
-
-		return [];
-	}
-
-	public resolveCodeLens(
-		codeLens: vscode.CodeLens,
-		token: vscode.CancellationToken,
-	) {
-		codeLens.command = {
-			title: 'Codelens provided by sample extension',
-			tooltip: 'Tooltip provided by sample extension',
-			command: 'codelens-sample.codelensAction',
-			arguments: ['Argument 1', false],
-		};
-		return codeLens;
-	}
-}
-
 export function activate(_context: vscode.ExtensionContext) {
 	context = _context;
 	createServer();
@@ -258,8 +191,4 @@ export function activate(_context: vscode.ExtensionContext) {
 		null,
 		context.subscriptions,
 	);
-
-	const codelensProvider = new CodelensProvider();
-
-	vscode.languages.registerCodeLensProvider('*', codelensProvider);
 }

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -176,6 +176,73 @@ function createServer() {
 	}
 }
 
+/**
+ * CodelensProvider
+ */
+export class CodelensProvider implements vscode.CodeLensProvider {
+	private codeLenses: vscode.CodeLens[] = [];
+	private readonly regex: RegExp;
+	private readonly _onDidChangeCodeLenses: vscode.EventEmitter<void> =
+		new vscode.EventEmitter<void>();
+
+	// eslint-disable-next-line @typescript-eslint/member-ordering
+	public readonly onDidChangeCodeLenses: vscode.Event<void> =
+		this._onDidChangeCodeLenses.event;
+
+	constructor() {
+		this.regex = /(.+)/g;
+
+		vscode.workspace.onDidChangeConfiguration((_) => {
+			this._onDidChangeCodeLenses.fire();
+		});
+	}
+
+	public provideCodeLenses(
+		document: vscode.TextDocument,
+		token: vscode.CancellationToken,
+	): vscode.CodeLens[] | Thenable<vscode.CodeLens[]> {
+		if (
+			vscode.workspace
+				.getConfiguration('codelens-sample')
+				.get('enableCodeLens', true)
+		) {
+			this.codeLenses = [];
+			const regex = new RegExp(this.regex);
+			const text = document.getText();
+			let matches;
+			while ((matches = regex.exec(text)) !== null) {
+				const line = document.lineAt(document.positionAt(matches.index).line);
+				const indexOf = line.text.indexOf(matches[0]);
+				const position = new vscode.Position(line.lineNumber, indexOf);
+				const range = document.getWordRangeAtPosition(
+					position,
+					new RegExp(this.regex),
+				);
+				if (range) {
+					this.codeLenses.push(new vscode.CodeLens(range));
+				}
+			}
+
+			return this.codeLenses;
+		}
+
+		return [];
+	}
+
+	public resolveCodeLens(
+		codeLens: vscode.CodeLens,
+		token: vscode.CancellationToken,
+	) {
+		codeLens.command = {
+			title: 'Codelens provided by sample extension',
+			tooltip: 'Tooltip provided by sample extension',
+			command: 'codelens-sample.codelensAction',
+			arguments: ['Argument 1', false],
+		};
+		return codeLens;
+	}
+}
+
 export function activate(_context: vscode.ExtensionContext) {
 	context = _context;
 	createServer();
@@ -191,4 +258,8 @@ export function activate(_context: vscode.ExtensionContext) {
 		null,
 		context.subscriptions,
 	);
+
+	const codelensProvider = new CodelensProvider();
+
+	vscode.languages.registerCodeLensProvider('*', codelensProvider);
 }

--- a/source/state.ts
+++ b/source/state.ts
@@ -1,0 +1,36 @@
+import * as vscode from 'vscode';
+import {type WebSocket} from 'ws';
+
+type Uri = string;
+type Field = {
+	uri: string;
+	document: vscode.TextDocument;
+	editor: vscode.TextEditor;
+	socket: WebSocket;
+};
+
+class State extends Map<Uri, Field> {
+	private readonly remove = new vscode.EventEmitter<Uri>();
+	private readonly add = new vscode.EventEmitter<Uri>();
+	// eslint-disable-next-line @typescript-eslint/member-ordering
+	readonly onRemove = this.remove.event;
+	// eslint-disable-next-line @typescript-eslint/member-ordering
+	readonly onAdd = this.add.event;
+
+	override set(uri: Uri, field: Field) {
+		super.set(uri, field);
+		this.add.fire(uri);
+		return this;
+	}
+
+	override delete(uri: Uri) {
+		const removed = super.delete(uri);
+		if (removed) {
+			this.remove.fire(uri);
+		}
+
+		return removed;
+	}
+}
+
+export const documents = new State();


### PR DESCRIPTION
Renaming files in VSCode is a mess, it requires a saved file _and_ it creates a new editor if you just rename a file, you have to take care of closing the previous editor. Madness.

So this extension will not use `👻🌕` as an indicator (which isn't great to begin with)

From a cursory check of VS Code’s capabilities, I think using a CodeLens widget on the first line is the best way to expose this information.

It would something like like:

```
	 👻 GhostText is connected [ Disconnect ]
  1  Lorem ipsum
  2  dolor sit
  3  amet
```

This has not been implemented it. The current code was copied from:

https://github.com/microsoft/vscode-extension-samples/blob/main/codelens-sample/src/extension.ts