### PR TITLE
add option to close editor window on save

### DIFF
--- a/source/extension.ts
+++ b/source/extension.ts
@@ -13,6 +13,7 @@ import {registerCommand, type Subscriptions} from './vscode.js';
 
 /** When the browser sends new content, the editor should not detect this "change" event and echo it */
 let updateFromBrowserInProgress = false;
+let isAutoClosingEditor = false; 
 
 const exec = promisify(execFile);
 let context: vscode.ExtensionContext;
@@ -139,9 +140,18 @@ async function onDocumentClose(closedDocument: vscode.TextDocument) {
 	if (!field) {
 		return;
 	}
+
+	if (isAutoClosingEditor) {
+		isAutoClosingEditor = false
+		return
+	}
+
 	if (closedDocument.isClosed) {
 		documents.delete(closedDocument.uri.toString());
 	}
+
+	isAutoClosingEditor = true
+	await vscode.commands.executeCommand('workbench.action.closeActiveEditor')
 }
 
 async function onLocalSelection(event: vscode.TextEditorSelectionChangeEvent) {

--- a/source/extension.ts
+++ b/source/extension.ts
@@ -135,6 +135,10 @@ function onDisconnectCommand(
 
 async function onDocumentClose(closedDocument: vscode.TextDocument) {
 	// https://github.com/fregante/GhostText-for-VSCode/issues/2
+	const field = documents.get(closedDocument.uri.toString());
+	if (!field) {
+		return;
+	}
 	if (closedDocument.isClosed) {
 		documents.delete(closedDocument.uri.toString());
 	}


### PR DESCRIPTION
Ensure text editor closes programmatically on document save, eliminating the need to manually close lingering windows.